### PR TITLE
Updated `Command` to allow an `anyMessage` listening

### DIFF
--- a/src/de/lesh/mootboot/Command.java
+++ b/src/de/lesh/mootboot/Command.java
@@ -5,4 +5,5 @@ import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 public interface Command {
   String getName();
   void execute(String commandline, String[] args, MessageReceivedEvent event);
+  void onMessageAnyReceived(MessageReceivedEvent event);
 }


### PR DESCRIPTION
Updated `Command` to allow an `anyMessage` listening (required for `CommandUser` to work)