### PR TITLE
Removed redundant permission check

### DIFF
--- a/src/de/lesh/mootboot/commands/ideenOutput.java
+++ b/src/de/lesh/mootboot/commands/ideenOutput.java
@@ -25,8 +25,8 @@ public class ideenOutput extends ListenerAdapter{
 		}
 		
 		String ideenVar = e.getMessage().getRawContent().split("\\s+",3)[2];
-	    if(msg.getRawContent().toLowerCase().startsWith("-ideen add") && !bannedList.black.contains(e.getAuthor().getIdLong())){
-	    	ideen.ideas.add(ideenVar);    
-	    }
+	   	if(msg.getRawContent().toLowerCase().startsWith("-ideen add")){
+	    		ideen.ideas.add(ideenVar);    
+	    	}
 	}
 }


### PR DESCRIPTION
Removed `bannedList.black.contains(e.getAuthor().getIdLong())`, cause it is already tested for that earlier.